### PR TITLE
AUnit warning zcl excel reader huge file "# au  > "#au #739 (#742)

### DIFF
--- a/src/demos/zdemo_calendar_classes.prog.abap
+++ b/src/demos/zdemo_calendar_classes.prog.abap
@@ -63,12 +63,10 @@ ENDCLASS.                    "ZCL_DATE_CALCULATION IMPLEMENTATION
 *
 *----------------------------------------------------------------------*
 CLASS zcl_date_calculation_test DEFINITION FOR TESTING
-  " DURATION SHORT
-  " RISK LEVEL HARMLESS
-  "#AU Duration Medium
-  "#AU Risk_Level Harmless
+    DURATION SHORT
+    RISK LEVEL HARMLESS
   .
-  PUBLIC SECTION.
+  PRIVATE SECTION.
     METHODS:
       months_between_two_dates FOR TESTING.
 ENDCLASS.                    "zcl_date_calculation_test DEFINITION

--- a/src/zcl_excel_common.clas.testclasses.abap
+++ b/src/zcl_excel_common.clas.testclasses.abap
@@ -6,8 +6,9 @@ CLASS zcl_excel_common DEFINITION LOCAL FRIENDS lcl_excel_common_test.
 *----------------------------------------------------------------------*
 *
 *----------------------------------------------------------------------*
-CLASS lcl_excel_common_test DEFINITION FOR TESTING  "#AU Risk_Level Harmless
-                                 .                  "#AU Duration Short
+CLASS lcl_excel_common_test DEFINITION FOR TESTING
+    RISK LEVEL HARMLESS
+    DURATION SHORT.
 *?ï»¿<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
 *?<asx:values>
 *?<TESTCLASS_OPTIONS>

--- a/src/zcl_excel_reader_huge_file.clas.testclasses.abap
+++ b/src/zcl_excel_reader_huge_file.clas.testclasses.abap
@@ -3,8 +3,10 @@ class lcl_test definition deferred.
 class zcl_excel_reader_huge_file definition local friends lcl_test.
 
 *
-class lcl_test definition for testing  " #AU Risk_Level Harmless
-      inheriting from cl_aunit_assert. " #AU Duration Short
+class lcl_test definition for testing
+      inheriting from cl_aunit_assert
+      risk level harmless
+      duration short.
 
   private section.
     data:

--- a/src/zcl_excel_worksheet.clas.testclasses.abap
+++ b/src/zcl_excel_worksheet.clas.testclasses.abap
@@ -1,7 +1,7 @@
 
-CLASS LCL_EXCEL_WORKSHEET_TEST DEFINITION FOR TESTING
-  "#AU Risk_Level Harmless
-  "#AU Duration Short
+CLASS lcl_excel_worksheet_test DEFINITION FOR TESTING
+    RISK LEVEL HARMLESS
+    DURATION SHORT
 .
 *?﻿<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
 *?<asx:values>


### PR DESCRIPTION
* Fix #739 AUnit warning ZCL_EXCEL_READER_HUGE_FILE

Useless warning in ABAP Unit tests of ZCL_EXCEL_READER_HUGE_FILE (reason: extra space "# AU -> "#AU) #739

* remove #AU everywhere in abap2xlsx

Co-authored-by: Jane Doe <Jane.Doe@World.com>
Co-authored-by: sandraros <sandra.rossi@gmail.com>